### PR TITLE
fixed cell prob and one def error

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1490044623808" name="duplicate:http://purl.obolibrary.org/obo/TEMP.owl" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1490044623808" name="duplicate:http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1490044623808" name="http://purl.obolibrary.org/obo/cl.owl" uri="imports/cl_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1490044623808" name="http://purl.obolibrary.org/obo/plana/imports/ro_import.owl" uri="imports/ro_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1490044623808" name="http://purl.obolibrary.org/obo/plana/imports/uberon_import.owl" uri="imports/uberon_import.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1490044623808" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1490044623808" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490124453092" name="duplicate:http://purl.obolibrary.org/obo/TEMP.owl" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490124453092" name="duplicate:http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490124453092" name="http://purl.obolibrary.org/obo/cl.owl" uri="imports/cl_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490124453092" name="http://purl.obolibrary.org/obo/plana/imports/ro_import.owl" uri="imports/ro_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490124453092" name="http://purl.obolibrary.org/obo/plana/imports/uberon_import.owl" uri="imports/uberon_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490124453092" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490124453092" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
     </group>
 </catalog>

--- a/src/ontology/imports/catalog-v001.xml
+++ b/src/ontology/imports/catalog-v001.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
+        <uri id="Automatically generated entry, Timestamp=1490120877199" name="http://purl.obolibrary.org/obo/cl.owl" uri="cl_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490120877199" name="http://purl.obolibrary.org/obo/plana/imports/ro_import.owl" uri="ro_import.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1490120877199" name="http://purl.obolibrary.org/obo/plana/imports/uberon_import.owl" uri="uberon_import.owl"/>
+    </group>
+</catalog>

--- a/src/ontology/imports/uberon_import.owl
+++ b/src/ontology/imports/uberon_import.owl
@@ -1463,26 +1463,10 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CL_0000000 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0005575"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A material entity of anatomical origin (part of or deriving from an organism) that has as its parts a maximally connected cell compartment surrounded by a plasma membrane.</obo:IAO_0000115>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cell</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A material entity of anatomical origin (part of or deriving from an organism) that has as its parts a maximally connected cell compartment surrounded by a plasma membrane.</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:mah</oboInOwl:hasDbXref>
-    </owl:Axiom>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0005575 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0005575">
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cellular_component</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cellular component</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -610,6 +610,10 @@
         <Class abbreviatedIRI="obo:PLANA_0000041"/>
     </Declaration>
     <SubClassOf>
+        <Class abbreviatedIRI="obo:GO_0005575"/>
+        <Class abbreviatedIRI="obo:PLANA_0000127"/>
+    </SubClassOf>
+    <SubClassOf>
         <Class abbreviatedIRI="obo:PLANA_0000001"/>
         <Class abbreviatedIRI="obo:PLANA_0000116"/>
     </SubClassOf>
@@ -8279,11 +8283,6 @@
         <AnnotationProperty abbreviatedIRI="obo:IAO_0000115"/>
         <IRI>#Organism_Subdivision</IRI>
         <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Anatomical structure which is a subdivision of a whole organism, consisting of components of multiple anatomical systems, largely surrounded by a contiguous region of integument.</Literal>
-    </AnnotationAssertion>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="obo:IAO_0000115"/>
-        <IRI>#Organism_Subdivision</IRI>
-        <Literal datatypeIRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">Anatomical structure which is a subdivision of the whole developing/ embryonic organism, consisting of componebts of multiple anatomical systems.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="oboInOwl:hasDbXref"/>


### PR DESCRIPTION
deleted uberon import instance of cell and moved the rest of cell
component under “our” cell class. Since a cell component is part of a
cell. I also identified one of the errors sofia was getting (associated
with uberon term 0000475) turns out organ subdivision had two
definitions assigned to it by accident! I deleted one.
I also made this as a new branch fix so that I think this will be easier for Sofia. 