### PR TITLE
added manus as synonym with reference and minor italicization.

### DIFF
--- a/metadata/planarefs/planaref-0000006.md
+++ b/metadata/planarefs/planaref-0000006.md
@@ -1,0 +1,12 @@
+--- 
+authors: Maher, B.
+external_accession: 
+id: PLANA_REF:0000016
+url: http://blogs.nature.com/inthefield/2007/12/a_worm_with_two_heads_at_ascb.html
+year: 2007
+layout: goref
+---
+
+## A worm with two heads at ASCB 2007
+
+Maher, B. (2007, December 3). A worm with two heads at ASCB 2007. [Blog post] Retrieved from http://blogs.nature.com/inthefield/2007/12/a_worm_with_two_heads_at_ascb.html

--- a/src/metadata/plana.md
+++ b/src/metadata/plana.md
@@ -27,4 +27,4 @@ license:
   label: CC-BY
 ---
 
-Anatomy ontology for planaria and terms specific to the developmental stages of the planarian __Schmidtea mediterranea__
+Anatomy ontology for planaria and terms specific to the developmental stages of the planarian _Schmidtea mediterranea_.

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -555,7 +555,7 @@ PMID:17376870</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007528">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000561"/>
-        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A non-neuronal cell of the nervous system. They not only provide physical support, but also respond to injury, regulate the ionic and chemical composition of the extracellular milieu. Guide neuronal migration during development, and exchange metabolites with neurons.</IAO_0000115>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A non-neuronal cell of the nervous system. They not only provide physical support, but also respond to injury, regulate the ionic and chemical composition of the extracellular milieu, guide neuronal migration during development, and exchange metabolites with neurons.</IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-06-22T17:12:28Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000125</oboInOwl:hasDbXref>
@@ -566,7 +566,7 @@ PMID:17376870</oboInOwl:hasDbXref>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/PLANA_0007528"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A non-neuronal cell of the nervous system. They not only provide physical support, but also respond to injury, regulate the ionic and chemical composition of the extracellular milieu. Guide neuronal migration during development, and exchange metabolites with neurons.</owl:annotatedTarget>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A non-neuronal cell of the nervous system. They not only provide physical support, but also respond to injury, regulate the ionic and chemical composition of the extracellular milieu, guide neuronal migration during development, and exchange metabolites with neurons.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PMID: 27612384</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -1556,7 +1556,7 @@ PMID:17376870</oboInOwl:hasDbXref>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The nervous system is an organ system containing predominantly neuron and glial cells. In bilaterally symmetrical organism, it is arranged in a network of tree-like structures connected to a central body. The main functions of the nervous system are to regulate and control body functions, and to receive sensory input, process this information, and generate behavior [CUMBO].</IAO_0000115>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The nervous system is an organ system containing predominantly neuron and glial cells. In bilaterally symmetrical organisms, it is arranged in a network of tree-like structures connected to a central body. The main functions of the nervous system are to regulate and control body functions, and to receive sensory input, process this information, and generate behavior [CUMBO].</IAO_0000115>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001016</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000025</oboInOwl:id>
@@ -1565,7 +1565,7 @@ PMID:17376870</oboInOwl:hasDbXref>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000025"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The nervous system is an organ system containing predominantly neuron and glial cells. In bilaterally symmetrical organism, it is arranged in a network of tree-like structures connected to a central body. The main functions of the nervous system are to regulate and control body functions, and to receive sensory input, process this information, and generate behavior [CUMBO].</owl:annotatedTarget>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The nervous system is an organ system containing predominantly neuron and glial cells. In bilaterally symmetrical organisms, it is arranged in a network of tree-like structures connected to a central body. The main functions of the nervous system are to regulate and control body functions, and to receive sensory input, process this information, and generate behavior [CUMBO].</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001016</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -4290,7 +4290,7 @@ PMID:17376870</oboInOwl:hasDbXref>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The renal system in an anatomical system that maintains fluid balance and contributes to electrolyte balance, acid/base balance, and disposal of nitrogenous waste products.</IAO_0000115>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The renal system is an anatomical system that maintains fluid balance and contributes to electrolyte balance, acid/base balance, and disposal of nitrogenous waste products.</IAO_0000115>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001008</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000088</oboInOwl:id>
@@ -4788,7 +4788,7 @@ PMID:17376870</oboInOwl:hasDbXref>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000072"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cell that is usually found in a two-dimensional sheet with a free surface. The cell has a cytoskeleton that allows for tight cell to cell contact and for cell polarity where apical part is directed towards the lumen and the basal part to the basal lamina.</IAO_0000115>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A cell that is usually found in a two-dimensional sheet with a free surface. The cell has a cytoskeleton that allows for tight cell to cell contact and for cell polarity where the apical part is directed towards the lumen and the basal part to the basal lamina.</IAO_0000115>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000066</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000100</oboInOwl:id>
@@ -8312,7 +8312,7 @@ PMID: 27149082</oboInOwl:hasDbXref>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000428"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pharynx muscle fibers runnering anteroposterior which lie beneath both the inner circular muscle fibers and the apical, ciliated portion of the epithium lining the lumenal surface.</IAO_0000115>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pharynx muscle fibers running anteroposterior which lie beneath both the inner circular muscle fibers and the apical, ciliated portion of the epithium lining the lumenal surface.</IAO_0000115>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000475</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">inner pharyngeal longitudinal muscle fiber</rdfs:label>
@@ -8320,7 +8320,7 @@ PMID: 27149082</oboInOwl:hasDbXref>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000475"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pharynx muscle fibers runnering anteroposterior which lie beneath both the inner circular muscle fibers and the apical, ciliated portion of the epithium lining the lumenal surface.</owl:annotatedTarget>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pharynx muscle fibers running anteroposterior which lie beneath both the inner circular muscle fibers and the apical, ciliated portion of the epithium lining the lumenal surface.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASIN:B000M4NK9M</oboInOwl:hasDbXref>
     </owl:Axiom>
     
@@ -8725,7 +8725,7 @@ PMID: 27149082</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000487">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000485"/>
-        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of two distinct histochemical classes of gland cells, these can be found throughout the body but primarily form clusters of subepidermal marginal adhesive glands along the dorsal/ ventral border of the animal. May also be refered to as eosinophilic gland cells.</IAO_0000115>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of two distinct histochemical classes of gland cells, these can be found throughout the body but primarily form clusters of subepidermal marginal adhesive glands along the dorsal/ ventral border of the animal. May also be referred to as eosinophilic gland cells.</IAO_0000115>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000487</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acidophilic gland cell</rdfs:label>
@@ -8733,7 +8733,7 @@ PMID: 27149082</oboInOwl:hasDbXref>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000487"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of two distinct histochemical classes of gland cells, these can be found throughout the body but primarily form clusters of subepidermal marginal adhesive glands along the dorsal/ ventral border of the animal. May also be refered to as eosinophilic gland cells.</owl:annotatedTarget>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">One of two distinct histochemical classes of gland cells, these can be found throughout the body but primarily form clusters of subepidermal marginal adhesive glands along the dorsal/ ventral border of the animal. May also be referred to as eosinophilic gland cells.</owl:annotatedTarget>
         <oboInOwl:hasDbXref>PMID: 20865784</oboInOwl:hasDbXref>
     </owl:Axiom>
     

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -1116,7 +1116,6 @@ PMID:17376870</oboInOwl:hasDbXref>
             </owl:Restriction>
         </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plicate and protrusible organ that is the sole point of entry and exit for the Triclad gut. It contains epithelial, muscular, secretory and neuronal cell types.</IAO_0000115>
-        <hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manus</hasExactSynonym>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000016</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definitive pharynx</rdfs:label>
@@ -1126,12 +1125,6 @@ PMID:17376870</oboInOwl:hasDbXref>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plicate and protrusible organ that is the sole point of entry and exit for the Triclad gut. It contains epithelial, muscular, secretory and neuronal cell types.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OCLC:16809160</oboInOwl:hasDbXref>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000016"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/hasExactSynonym"/>
-        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manus</owl:annotatedTarget>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/obophenotype/planaria-ontology/blob/master/metadata/planarefs/planaref-0000006.md</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 
@@ -3681,6 +3674,7 @@ PMID:17376870</oboInOwl:hasDbXref>
             </owl:Restriction>
         </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The sole point of entry and exit for the Triclad planarian flatworm gut. The mouth is connected to the pharyngeal pouch to allow for exit and re-entry of the definitive pharynx on the ventral side of the animal. The mouth contains several cell types, including epithelial cells, muscle, and secretory cells.</IAO_0000115>
+        <hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manus</hasExactSynonym>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000072</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mouth</rdfs:label>
@@ -3690,6 +3684,12 @@ PMID:17376870</oboInOwl:hasDbXref>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The sole point of entry and exit for the Triclad planarian flatworm gut. The mouth is connected to the pharyngeal pouch to allow for exit and re-entry of the definitive pharynx on the ventral side of the animal. The mouth contains several cell types, including epithelial cells, muscle, and secretory cells.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OCLC:16809160</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000072"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manus</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/obophenotype/planaria-ontology/blob/master/metadata/planarefs/planaref-0000006.md</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -1116,6 +1116,7 @@ PMID:17376870</oboInOwl:hasDbXref>
             </owl:Restriction>
         </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plicate and protrusible organ that is the sole point of entry and exit for the Triclad gut. It contains epithelial, muscular, secretory and neuronal cell types.</IAO_0000115>
+        <hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manus</hasExactSynonym>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000016</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definitive pharynx</rdfs:label>
@@ -1125,6 +1126,12 @@ PMID:17376870</oboInOwl:hasDbXref>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plicate and protrusible organ that is the sole point of entry and exit for the Triclad gut. It contains epithelial, muscular, secretory and neuronal cell types.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OCLC:16809160</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000016"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manus</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/obophenotype/planaria-ontology/blob/master/metadata/planarefs/planaref-0000006.md</oboInOwl:hasDbXref>
     </owl:Axiom>
     
 


### PR DESCRIPTION
The use of "manus" as a synonym for pharynx can be found a few places online, I've heard it in multiple talks and it is used colloquially.  There may be a way to flag the synonym as "not preferred" or as "colloquial".  Colloquial ontology terms can find there way into widespread use (see "thagomizer").  Synonyms seem like the best way to deal with such terms.

Online usage:
http://blogs.nature.com/inthefield/2007/12/a_worm_with_two_heads_at_ascb.html
https://www.freezingblue.com/flashcards/print_preview.cgi?cardsetID=203930
https://quizlet.com/181258928/unit-4-marine-worms-mollusks-flatworms-parasites-flash-cards/

I only included the synonym on definitive pharynx, as I've never seen or heard the term used in reference to the embryonic pharynx.  Does this need to be corrected?

There may be additional is_a terms for a combined mouth-anus as there are cases of species with a single orifice, but without a pharynx. (e.g. cnidarians).  
