### PR TITLE
07242017 STN

### DIFF
--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921264680" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921813105" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921060821" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921224732" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924385007" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924560544" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924116362" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924385007" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921995381" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922229729" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500927792121" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500929040430" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921813105" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921995381" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500924560544" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925016391" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921224732" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921239856" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500921239856" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921264680" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922229729" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922686595" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922705722" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500924116362" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1498164166724" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500921060821" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925914806" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500927792121" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500922686595" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500922705722" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1500925016391" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/" uri="plana-edit.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/TEMP.owl" uri="plana.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/ro.owl" uri="mirror/ro.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="http://purl.obolibrary.org/obo/uberon.owl" uri="mirror/uberon.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="https://github.com/obophenotype/planaria-ontology/raw/master/src/ontology/imports/uberon_slim_import_04072017.owl" uri="imports/uberon_slim_import_04072017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/cl_slim_import_04052017.owl" uri="imports/cl_slim_import_04052017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="https://raw.githubusercontent.com/obophenotype/planaria-ontology/master/src/ontology/imports/ro_slim_import_03282017.owl" uri="imports/ro_slim_import_03282017.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1500925914806" name="shadowed:http://purl.obolibrary.org/obo/" uri="to_consider/plana-toConsider.owl"/>
     </group>
 </catalog>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -2963,12 +2963,6 @@ PMID:17376870</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000034"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0001005"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000014"/>
             </owl:Restriction>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -640,6 +640,30 @@ PMID:17376870</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000420"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000007"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000008"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the sexual biotype animal lateral to and surrounding the pharyngeal pouch.</IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:38:16Z</oboInOwl:creation_date>
@@ -654,6 +678,12 @@ PMID:17376870</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007531">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000420"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004504"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the  asexual biotype animal lateral to and surrounding the pharyngeal pouch.</IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:38:28Z</oboInOwl:creation_date>
@@ -668,6 +698,12 @@ PMID:17376870</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007532">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000419"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004504"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the asexual biotype animal between the posterior end of the cephalic ganglia and the anterior end of the definitive pharynx.</IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:41:25Z</oboInOwl:creation_date>
@@ -682,6 +718,30 @@ PMID:17376870</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007533">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000419"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000007"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000008"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002131"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the juvenile or adult sexual biotype animal between the posterior end of the cephalic ganglia and the anterior end of the definitive pharynx.</IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:41:33Z</oboInOwl:creation_date>
@@ -7559,24 +7619,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000007"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000008"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO:0000051"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000061"/>
             </owl:Restriction>
@@ -7611,24 +7653,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000420">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000417"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000007"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000008"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO:0000051"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -7008,6 +7008,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000408"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0001005"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
             </owl:Restriction>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -752,6 +752,20 @@ PMID:17376870</oboInOwl:hasDbXref>
     
 
 
+    <!-- http://purl.obolibrary.org/PLANA_0007534 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007534">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000016"/>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heavily ciliated epidermal cells covering the inner surface of the pharynx shaft.</IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T19:28:03Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0007534</oboInOwl:id>
+        <rdfs:label xml:lang="en">inner pharyngeal epithlium</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/CL_0000354 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000354">

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -10117,7 +10117,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000044"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000075"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000080"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000099"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000205"/>
@@ -10145,7 +10144,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000044"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000075"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000080"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000099"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000460"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -7560,18 +7560,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004504"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000007"/>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -7623,18 +7611,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000420">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000417"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004504"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -756,6 +756,12 @@ PMID:17376870</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007534">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000016"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000474"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heavily ciliated epidermal cells covering the inner surface of the pharynx shaft.</IAO_0000115>
         <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T19:28:03Z</oboInOwl:creation_date>
@@ -8708,13 +8714,19 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0001107"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000474"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0007534"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000474"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000475"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002102"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000016"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -9913,7 +9913,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000205"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000460"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000461"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000463"/>
@@ -9941,7 +9940,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000099"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000460"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000461"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000463"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -9913,7 +9913,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000205"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000460"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000461"/>
@@ -9942,7 +9941,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000099"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000460"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000461"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -2963,6 +2963,12 @@ PMID:17376870</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000034"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0001005"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000014"/>
             </owl:Restriction>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -8693,6 +8693,18 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000477"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0001107"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000474"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000474"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000429"/>
             </owl:Restriction>
@@ -8752,6 +8764,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000475">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000119"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000241"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0001107"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000474"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -7916,6 +7916,24 @@ PMID: 27149082</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000426">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000424"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004504"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000040</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0000426</oboInOwl:id>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -88,15 +88,30 @@
     
 
 
+    <!-- http://purl.obolibrary.org/PLANA_0007536 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/PLANA_0007536">
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feature restricted to</IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T20:21:09Z</oboInOwl:creation_date>
+        <rdfs:label xml:lang="en">specific_to</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/BFO:0000050 -->
 
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO:0000050"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO:0000050">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part_of</rdfs:label>
+    </owl:ObjectProperty>
     
 
 
     <!-- http://purl.obolibrary.org/obo/BFO:0000051 -->
 
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO:0000051"/>
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO:0000051">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</rdfs:label>
+    </owl:ObjectProperty>
     
 
 

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -7206,6 +7206,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000408"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000407"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
             </owl:Restriction>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -7080,6 +7080,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000408"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000405"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
             </owl:Restriction>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -772,6 +772,69 @@ PMID:17376870</oboInOwl:hasDbXref>
     
 
 
+    <!-- http://purl.obolibrary.org/PLANA_0007535 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007535">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/PLANA_0000478"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000119"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000429"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004504"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000214"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO:0000050"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000016"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO:0000050"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000049"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO:0000050"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000428"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pharynx muscle fibers running parallel to the diameter of the pharynx.</IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T19:39:14Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0007535</oboInOwl:id>
+        <rdfs:label xml:lang="en">pharyngeal circular muscle fiber</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/PLANA_0007535"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pharynx muscle fibers running parallel to the diameter of the pharynx.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ASIN:B000M4NK9M</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/CL_0000354 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000354">
@@ -8115,6 +8178,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000429"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
             </owl:Restriction>
@@ -8642,8 +8711,8 @@ PMID: 27149082</oboInOwl:hasDbXref>
     <!-- http://purl.obolibrary.org/obo/PLANA_0000473 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000473">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/PLANA_0007535"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000119"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000477"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0001107"/>
@@ -8709,8 +8778,8 @@ PMID: 27149082</oboInOwl:hasDbXref>
     <!-- http://purl.obolibrary.org/obo/PLANA_0000474 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000474">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/PLANA_0007535"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000119"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000477"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0001107"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -9884,7 +9884,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000205"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000406"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000407"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000413"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
@@ -9916,7 +9915,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000406"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000407"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000413"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -9883,7 +9883,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000205"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000406"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000413"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
@@ -9914,7 +9913,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000099"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000406"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000413"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -6895,6 +6895,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000242"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000413"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
             </owl:Restriction>
@@ -9908,7 +9914,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000205"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000413"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000460"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000461"/>
@@ -9938,7 +9943,6 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000103"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000124"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000412"/>
-        <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000413"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000414"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000460"/>
         <rdf:type rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000461"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -636,6 +636,62 @@ PMID:17376870</oboInOwl:hasDbXref>
     
 
 
+    <!-- http://purl.obolibrary.org/PLANA_0007530 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007530">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000420"/>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the sexual biotype animal lateral to and surrounding the pharyngeal pouch.</IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:38:16Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0007530</oboInOwl:id>
+        <rdfs:label xml:lang="en">sexual parapharyngeal region</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/PLANA_0007531 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007531">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000420"/>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the  asexual biotype animal lateral to and surrounding the pharyngeal pouch.</IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:38:28Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0007531</oboInOwl:id>
+        <rdfs:label xml:lang="en">asexual parapharyngeal region</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/PLANA_0007532 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007532">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000419"/>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the asexual biotype animal between the posterior end of the cephalic ganglia and the anterior end of the definitive pharynx.</IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:41:25Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA_0007532</oboInOwl:id>
+        <rdfs:label xml:lang="en">asexual neck</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/PLANA_0007533 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/PLANA_0007533">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000419"/>
+        <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region of the juvenile or adult sexual biotype animal between the posterior end of the cephalic ganglia and the anterior end of the definitive pharynx.</IAO_0000115>
+        <oboInOwl:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Steph Nowotarski</oboInOwl:created_by>
+        <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-07-24T18:41:33Z</oboInOwl:creation_date>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLANA:0007533</oboInOwl:id>
+        <rdfs:label xml:lang="en">sexual neck</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/CL_0000354 -->
 
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000354">

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -8571,6 +8571,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000037"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000476"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002490"/>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/PLANA_0004503"/>
             </owl:Restriction>
@@ -8618,6 +8624,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000473">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000119"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000477"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0001107"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000476"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>
@@ -8801,6 +8813,18 @@ PMID: 27149082</oboInOwl:hasDbXref>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000476">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000119"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000241"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0001107"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000472"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000473"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002202"/>

--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -6923,6 +6923,12 @@ PMID: 27149082</oboInOwl:hasDbXref>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PLANA_0000408">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000401"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BSPO_0015014"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PLANA_0000404"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A two dimensional anatomical structure that is the boundary between an anatomical structure and an anatomical substance, an anatomical space or the organism&apos;s environment. Examples include the surface of your skin, the surface of the lining of your gut; the surface of the endothelium of you aorta that is in contact with blood.</IAO_0000115>
         <oboInOwl:hasDbXref>UBERON:0006984</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Planarian_Anatomy</oboInOwl:hasOBONamespace>


### PR DESCRIPTION
Top to bottom checked ELDs relationships - especially in the immaterial anatomical entity section. Mostly removed any present instances of sexual and asexual biotypes as we decided  instances are off limits and that we should be duplicating these classes as 'sexual_class', 'asexual_class' in order to distinguish anatomical differences between biotypes. Like ZFA does. 

Added use of relationship: immediately_superficial_to to clarify some relationships and juxtaposition of anatomical features. Should we be moving forward with this? Mostly did this for surface and space relationships. i.e. basal epidermis surface immediately_superficial_to some basal lamina of epithelium

addition of inner pharyngeal epithlium, pharyngeal circular muscle fiber classes 

Added biotype specific child classes for "parapharyngeal region", "neck"​
I ensured that childclasses held the most specific biotype information rather than the old parent class in these instances.