### PR TITLE
Update OBO interconversion of PLANA

### DIFF
--- a/src/ontology/plana-edit.owl
+++ b/src/ontology/plana-edit.owl
@@ -590,9 +590,11 @@ AnnotationAssertion(rdfs:label obo:RO_0002579 "is indirect form of"^^xsd:string)
 AnnotationAssertion(obo:IAO_0000115 obo:PLANA_0007536 "feature restricted to"^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:PLANA_0007536 "Steph Nowotarski"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:PLANA_0007536 "2017-07-24T20:21:09Z"^^xsd:string)
+AnnotationAssertion(oboInOwl:hasDbXref obo:PLANA_0007536 "PLANA:0007536"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:PLANA_0007536 "Planarian_Relationship"^^xsd:string)
-AnnotationAssertion(rdfs:label obo:PLANA_0007536 "specific_to"^^xsd:string)
-AnnotationAssertion(skos:altLabel obo:PLANA_0007536 "specific to")
+AnnotationAssertion(oboInOwl:id obo:PLANA_0007536 "specific_to"^^xsd:string)
+AnnotationAssertion(oboInOwl:shorthand obo:PLANA_0007536 "specific_to"^^xsd:string)
+AnnotationAssertion(rdfs:label obo:PLANA_0007536 "specific to"^^xsd:string)
 
 
 
@@ -1326,8 +1328,7 @@ SubClassOf(obo:PLANA_0000043 ObjectSomeValuesFrom(obo:RO_0002490 obo:PLANA_00045
 
 # Class: obo:PLANA_0000044 (cephalic ganglia)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "OCLC:16809160
-PMID:17999079"^^xsd:string) obo:IAO_0000115 obo:PLANA_0000044 "The planarian brain, consisting of two bilaterally symmetric lobes occupying a ventral position in the head."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "OCLC:16809160"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:17999079"^^xsd:string) obo:IAO_0000115 obo:PLANA_0000044 "The planarian brain, consisting of two bilaterally symmetric lobes occupying a ventral position in the head."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:PLANA_0000044 "brain"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:PLANA_0000044 "Planarian_Anatomy"^^xsd:string)
 AnnotationAssertion(oboInOwl:id obo:PLANA_0000044 "PLANA:0000044"^^xsd:string)


### PR DESCRIPTION
Hi !

This PR does two things to improve conversion of PLANA to OBO format:
* fix separate db-xrefs annotations that were merged in the same annotation.
* use OBO shortcut for definition of the `restricted_to` relationship.

The `restricted_to` fix will have the effect to change the contents of `plana.obo` from this:
```ini
[Term]
id: PLANA:0000001
relationship: PLANA:0007536 PLANA:0000027 ! specific_to Smed sexual biotype

[Typedef]
id: PLANA:0007536
name: specific_to
```
to the semantically equivalent but easier to work with in OBO:
```ini 
[Term]
id: PLANA:0000001
relationship: specific_to PLANA:0000027 ! Smed sexual biotype

[Typedef]
id: specific_to
name: specific to
xref: PLANA:0007536
```

